### PR TITLE
Move guard setup to .hanami.server.guardfile

### DIFF
--- a/lib/hanami/reloader/cli.rb
+++ b/lib/hanami/reloader/cli.rb
@@ -10,7 +10,7 @@ module Hanami
         desc "Generate configuration for code reloading"
 
         def call(*)
-          path = Hanami.root.join("Guardfile")
+          path = Hanami.root.join(".hanami.server.guardfile")
 
           files.touch(path)
           files.append path, <<~CODE
@@ -28,7 +28,7 @@ CODE
         desc "Starts the server with code reloading (only development) reloader"
 
         def call(*)
-          exec "bundle exec guard -i"
+          exec "bundle exec guard -G .hanami.server.guardfile"
         end
       end
     end

--- a/spec/integration/cli/generate_spec.rb
+++ b/spec/integration/cli/generate_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "CLI: hanami generate reloader", type: :cli do
     with_project do
       system "bundle exec hanami generate reloader"
 
-      expect(File.exist?("Guardfile")).to be(true)
+      expect(File.exist?(".hanami.server.guardfile")).to be(true)
 
       expected = <<~CODE
         guard "rack", port: ENV["HANAMI_PORT"] || 2300 do
@@ -16,7 +16,7 @@ RSpec.describe "CLI: hanami generate reloader", type: :cli do
 
 CODE
 
-      expect(File.read("Guardfile")).to eq(expected)
+      expect(File.read(".hanami.server.guardfile")).to eq(expected)
     end
   end
 end


### PR DESCRIPTION
I setup the `generate` command to create a new dotfile with the server setup so it does not change the default guardfile from the user.

That solves the issues with `dotenv` among other annoyances, like server output in the middle of test runs etc. 

Closes #1 