### PR TITLE
Avoid Guard prompt when shutting down the server

### DIFF
--- a/lib/hanami/reloader/cli.rb
+++ b/lib/hanami/reloader/cli.rb
@@ -28,7 +28,7 @@ CODE
         desc "Starts the server with code reloading (only development) reloader"
 
         def call(*)
-          exec "bundle exec guard -G .hanami.server.guardfile"
+          exec "bundle exec guard -n f -i -G .hanami.server.guardfile"
         end
       end
     end


### PR DESCRIPTION
```shell
➜ be hanami s
08:46:38 - INFO - Using Guardfile at /Users/luca/Code/bookshelf/app/.hanami.server.guardfile.
08:46:39 - INFO - Puma starting on port 2300 in development environment.
08:46:39 - INFO - Guard is now watching at '/Users/luca/Code/bookshelf/app'
[1] guard(main)> [47685] Puma starting in cluster mode...
[47685] * Version 3.11.2 (ruby 2.5.0-p0), codename: Love Song
[47685] * Min threads: 5, max threads: 5
[47685] * Environment: development
[47685] * Process workers: 2
[47685] * Preloading application

# Ctrl+C

# Type: quit<enter>
[1] guard(main)> quit

08:46:49 - ERROR - Guard::Puma failed to achieve its <stop>, exception was:
> [#f97fe1b4a33c] Errno::ECONNREFUSED: Failed to open TCP connection to localhost:9293 (Connection refused - connect(2) for "localhost" port 9293)
> [#f97fe1b4a33c] /Users/luca/.rubies/ruby-2.5.0/lib/ruby/2.5.0/net/http.rb:939:in `rescue in block in connect'
> [#f97fe1b4a33c] /Users/luca/.rubies/ruby-2.5.0/lib/ruby/2.5.0/net/http.rb:936:in `block in connect'
> [#f97fe1b4a33c] /Users/luca/.rubies/ruby-2.5.0/lib/ruby/2.5.0/timeout.rb:93:in `block in timeout'
> [#f97fe1b4a33c] /Users/luca/.rubies/ruby-2.5.0/lib/ruby/2.5.0/timeout.rb:103:in `timeout'
> [#f97fe1b4a33c] /Users/luca/.rubies/ruby-2.5.0/lib/ruby/2.5.0/net/http.rb:935:in `connect'
> [#f97fe1b4a33c] /Users/luca/.rubies/ruby-2.5.0/lib/ruby/2.5.0/net/http.rb:920:in `do_start'
> [#f97fe1b4a33c] /Users/luca/.rubies/ruby-2.5.0/lib/ruby/2.5.0/net/http.rb:909:in `start'
> [#f97fe1b4a33c] /Users/luca/.rubies/ruby-2.5.0/lib/ruby/2.5.0/net/http.rb:609:in `start'
> [#f97fe1b4a33c] /Users/luca/.rubies/ruby-2.5.0/lib/ruby/2.5.0/net/http.rb:485:in `get_response'
> [#f97fe1b4a33c] /Users/luca/.rubies/ruby-2.5.0/lib/ruby/2.5.0/net/http.rb:462:in `get'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-puma-0.4.1/lib/guard/puma/runner.rb:51:in `halt'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-puma-0.4.1/lib/guard/puma.rb:61:in `stop'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/runner.rb:83:in `block (2 levels) in _supervise'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/ui/config.rb:62:in `block in with_progname'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/lumberjack-1.0.12/lib/lumberjack/logger.rb:270:in `push_thread_local_value'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/lumberjack-1.0.12/lib/lumberjack/logger.rb:231:in `set_progname'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/ui/config.rb:61:in `with_progname'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/runner.rb:81:in `block in _supervise'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/runner.rb:79:in `catch'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/runner.rb:79:in `_supervise'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/runner.rb:22:in `block (3 levels) in run'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/runner.rb:121:in `block (2 levels) in _run_group_plugins'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/runner.rb:119:in `each'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/runner.rb:119:in `block in _run_group_plugins'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/runner.rb:118:in `catch'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/runner.rb:118:in `_run_group_plugins'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/runner.rb:21:in `block (2 levels) in run'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/runner.rb:20:in `each'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/runner.rb:20:in `block in run'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/lumberjack-1.0.12/lib/lumberjack.rb:32:in `unit_of_work'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/runner.rb:18:in `run'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/commander.rb:58:in `stop'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/commander.rb:50:in `start'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/cli/environments/valid.rb:16:in `start_guard'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/cli.rb:122:in `start'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/aruba_adapter.rb:32:in `execute'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/lib/guard/aruba_adapter.rb:19:in `execute!'
> [#f97fe1b4a33c] /Users/luca/.gem/ruby/2.5.0/gems/guard-2.14.2/bin/_guard-core:11:in `<main>'
08:46:49 - INFO - Guard::Puma has just been fired

08:46:49 - INFO - Bye bye...
```